### PR TITLE
Rename functions to emphasize must pattern

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,16 +11,16 @@ import (
 )
 
 func main() {
-	LoadEnv()
+	MustLoadEnv()
 
 	SetupLogger()
 
 	s := server.NewServer()
 	s.RegisterHandlers()
-	s.Run()
+	s.MustRun()
 }
 
-func LoadEnv() {
+func MustLoadEnv() {
 	if err := godotenv.Load(); err != nil {
 		log.Fatal("couldn't load env variables from .env file")
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,7 +32,7 @@ func (s Server) RegisterHandlers() {
 	s.Mux.HandleFunc("GET /bars", LoggerMiddleware(BarsHandler))
 }
 
-func (s Server) Run() {
+func (s Server) MustRun() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
 	go func() {


### PR DESCRIPTION
Rename functions to reflect a must pattern, enhancing clarity and intent in the codebase. This change improves the understanding of critical operations.