### PR TITLE
Add in-memory repository for car makes and models

### DIFF
--- a/internal/repository/in-memory.go
+++ b/internal/repository/in-memory.go
@@ -78,7 +78,7 @@ func GetCarMakes() ([]string, error) {
 }
 
 func GetCarMakesData(data Data) map[string]string {
-	makeData := make(map[string]string, 0)
+	makeData := make(map[string]string)
 	for _, parent := range data.Attributes.Make.Values {
 		carMake := strings.ToLower(parent.Name)
 		makeData[carMake] = parent.ID
@@ -137,6 +137,7 @@ func GetModelIDbyModelName(makeName string, modelName string) (string, error) {
 
 	makeData := GetCarMakesData(data)
 	makeName = strings.ToLower(makeName)
+	modelName = strings.ToLower(modelName)
 	makeID, ok := makeData[makeName]
 	if !ok {
 		return "", fmt.Errorf("make %q not found", makeName)

--- a/internal/repository/in-memory.go
+++ b/internal/repository/in-memory.go
@@ -113,3 +113,47 @@ func GetCarModelsByMake(makeName string) ([]string, error) {
 
 	return []string{}, fmt.Errorf("no car models found for that make")
 }
+
+func GetMakeIDbyMakeName(makeName string) (string, error) {
+	data, err := ReadData("./.temp/filters.json")
+	if err != nil {
+		return "", fmt.Errorf("couldn't get data, error: %w", err)
+	}
+
+	makeData := GetCarMakesData(data)
+	makeName = strings.ToLower(makeName)
+	makeID, ok := makeData[makeName]
+	if !ok {
+		return "", fmt.Errorf("make %q not found", makeName)
+	}
+	return makeID, nil
+}
+
+func GetModelIDbyModelName(makeName string, modelName string) (string, error) {
+	data, err := ReadData("./.temp/filters.json")
+	if err != nil {
+		return "", fmt.Errorf("couldn't get data, error: %w", err)
+	}
+
+	makeData := GetCarMakesData(data)
+	makeName = strings.ToLower(makeName)
+	makeID, ok := makeData[makeName]
+	if !ok {
+		return "", fmt.Errorf("make %q not found", makeName)
+	}
+
+	for _, parent := range data.Attributes.Model.Values {
+		if parent.ParentID != makeID {
+			continue
+		}
+		for _, model := range parent.Values {
+			carModel := strings.ToLower(model.Name)
+			if carModel != modelName {
+				continue
+			}
+			return model.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("no car model id found for that model name")
+}

--- a/internal/repository/in-memory.go
+++ b/internal/repository/in-memory.go
@@ -1,0 +1,115 @@
+package repository
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+type Filters struct {
+	Data Data `json:"data"`
+}
+
+type Data struct {
+	Type       string     `json:"type"`
+	Id         string     `json:"id"`
+	Attributes Attributes `json:"attributes"`
+}
+
+type Attributes struct {
+	Make  MakeRoot  `json:"make"`
+	Model ModelRoot `json:"model"`
+}
+
+type MakeRoot struct {
+	Values []Make `json:"values"`
+}
+
+type Make struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+type ModelRoot struct {
+	Values []ModelParent `json:"values"`
+}
+
+type ModelParent struct {
+	ParentID string     `json:"parent_id"`
+	Values   []CarModel `json:"values"`
+}
+
+type CarModel struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+func ReadData(path string) (Data, error) {
+	f, err := os.ReadFile(path)
+	if err != nil {
+		return Data{}, fmt.Errorf("couldn't read file with filters, error: %w", err)
+	}
+
+	var filters Filters
+	if err := json.Unmarshal(f, &filters); err != nil {
+		return Data{}, fmt.Errorf("couldn't unmarshal file with filters, error: %w", err)
+	}
+	slog.Debug("filters.json", "type", filters.Data.Type, "id", filters.Data.Id)
+
+	return filters.Data, nil
+}
+
+func GetCarMakes() ([]string, error) {
+	data, err := ReadData("./.temp/filters.json")
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get data, error: %w", err)
+	}
+
+	carMakes := make([]string, 0)
+	for _, parent := range data.Attributes.Make.Values {
+		carMake := strings.ToLower(parent.Name)
+		carMakes = append(carMakes, carMake)
+	}
+	return carMakes, nil
+}
+
+func GetCarMakesData(data Data) map[string]string {
+	makeData := make(map[string]string, 0)
+	for _, parent := range data.Attributes.Make.Values {
+		carMake := strings.ToLower(parent.Name)
+		makeData[carMake] = parent.ID
+	}
+	return makeData
+}
+
+func GetCarModelsByMake(makeName string) ([]string, error) {
+	data, err := ReadData("./.temp/filters.json")
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get data, error: %w", err)
+	}
+
+	makeData := GetCarMakesData(data)
+	makeName = strings.ToLower(makeName)
+	makeID, ok := makeData[makeName]
+	if !ok {
+		return nil, fmt.Errorf("make %q not found", makeName)
+	}
+
+	for _, parent := range data.Attributes.Model.Values {
+		if parent.ParentID != makeID {
+			continue
+		}
+		carModels := make([]string, 0, len(parent.Values))
+		for _, model := range parent.Values {
+			carModel := strings.ToLower(model.Name)
+			carModels = append(carModels, carModel)
+		}
+		return carModels, nil
+	}
+
+	return []string{}, fmt.Errorf("no car models found for that make")
+}

--- a/internal/scraper/car.go
+++ b/internal/scraper/car.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+
+	"github.com/2Cheetah/car-price-validator/internal/repository"
 )
 
 const (
@@ -29,10 +31,20 @@ func GetPageData(page int, make string, model string, year string) (Root, error)
 	params.Set("from", strconv.Itoa(from))
 	params.Set("include", "extra_images,body")
 	params.Set("limit", strconv.Itoa(PerPage))
-	params.Set("make_id", "36")
+
+	makeID, err := repository.GetMakeIDbyMakeName(make)
+	if err != nil {
+		return Root{}, fmt.Errorf("couldn't get make ID by make name, error: %w", err)
+	}
+	params.Set("make_id", makeID)
 	params.Set("mfg_year", fmt.Sprintf("%s-%s", year, year))
 	params.Set("mileage", "-100000")
-	params.Set("model_id", "1756")
+
+	modelID, err := repository.GetModelIDbyModelName(make, model)
+	if err != nil {
+		return Root{}, fmt.Errorf("couldn't get model ID by model name, error: %w", err)
+	}
+	params.Set("model_id", modelID)
 	params.Set("price", "-100000")
 	params.Set("type", "sell")
 	base.RawQuery = params.Encode()

--- a/internal/visualiser/visualiser.go
+++ b/internal/visualiser/visualiser.go
@@ -21,7 +21,6 @@ const (
 )
 
 func RenderHTML(make string, model string, year string) ([]byte, error) {
-	// validate input params
 	if err := ValidateMake(make); err != nil {
 		return []byte{}, err
 	}


### PR DESCRIPTION
Introduce an in-memory repository to manage car makes and models, enabling retrieval of IDs by name. Update validation functions in the visualiser to utilize this new repository for improved data handling. Refactor related functions for better clarity and efficiency.